### PR TITLE
svd df/f change

### DIFF
--- a/core/dffFromSVD.m
+++ b/core/dffFromSVD.m
@@ -1,12 +1,9 @@
-
-
 function [newU, newV] = dffFromSVD(U, V, meanImage)
 % function [newU, newV] = dffFromSVD(U, V, meanImage)
 % Function by K. Harris, edited by N. Steinmetz
 
 assert(nargout==2, 'behavior of dffFromSVD has changed, you must take new U and new V\n');
    
-
 [nX, nY, nSVD] = size(U);
 flatU = reshape(U, nX*nY,nSVD);
 meanV = flatU'*meanImage(:);
@@ -15,22 +12,16 @@ V0 = meanV + mean(V,2);
 
 newV= bsxfun(@minus,V,mean(V,2));
 
-% Here the "simpler way" produces a new U and new V, where as "cleverer
-% way" produces just a new V that keeps the old U. We've decided that the
-% cleverer way generally adds more noise than you'd like to an
-% already-noise-amplifying computation. 
-simplerWay = true; 
-if simplerWay
-        
-    newU = reshape(bsxfun(@rdivide,flatU,(flatU*V0)), [nX nY nSVD]);
+% Soft df/f the fluorescence in U-space
+% (by a factor of 1 * the average fluorescence value, looks ok)
+df_softnorm = mean(meanImage(:))*1;
+nonnormU = reshape(bsxfun(@rdivide,flatU,(flatU*V0)+df_softnorm), [nX nY nSVD]);
 
-else
-    
-    % "the cleverer way" (get to use the old U?)
-    test = bsxfun(@rdivide,flatU,flatU*V0); %DS
-    test(isnan(test(:))) = 0; %DS
-    normalizeMat = test'*flatU;
-    newV = normalizeMat*newV;
-    %newU = U;
-    
-end
+% new df/f U's aren't orthonormal: re-cast df/f V's into old U space
+newV = ChangeU(nonnormU,newV,U);
+newU = U;
+
+        
+
+
+


### PR DESCRIPTION
changed the dffFromSVD function:

1) changed the df/f to soft norm because zeros in the denominator caused all NaNs and low values blew up

2) more importantly: added a ChangeU call at the end of the function to but the df/f V's into the original U-space

I did this because I was attempting to use a common U-space across experiments, but I was getting weird changes in resulting signal amplitude. The reason was that the new U's after df/f-ing are not orthonormal, which is a requirement for a lot of operations that happen in V-space.