### PR TITLE
SubSampleShift: resample to interp1

### DIFF
--- a/generalUtils/SubSampleShift.m
+++ b/generalUtils/SubSampleShift.m
@@ -1,22 +1,26 @@
-function rV = SubSampleShift(V, p, q);
-% function Vs = SubSampleShift(V, p, q)
+function rV = SubSampleShift(V, p, q)
+% function rV = SubSampleShift(V, p, q)
 %
-% delays the vector time series V by p qths of a sample, using MATLAB's resample
-% function. Note that p and q should be positive integers (it doesn't do
-% negative shifts (yet))
+% delays the vector time series V by p qths of a sample
+% (used to overlap signals from alternating colors)
 
-% Transpose V to allow for conventional nSVs x nTimes input
-V = V';
+%%%% NEW (interp)
+rV = interp1(1:size(V,2),V',[1:size(V,2)]+(p/q))';
+rV(:,end) = V(:,end);
 
-meanV = mean(V);
-
-upV = resample(double(bsxfun(@minus,V, meanV)), q, 1) ;
-
-deciV = upV(p+1:q:end,:);
-
-%rV = bsxfun(@plus, resample(deciV, 1, q), meanV);
-rV = bsxfun(@plus,deciV, meanV);
-
-rV = rV';
+%%%% OLD (resample: could introduce large error on last sample)
+% % Transpose V to allow for conventional nSVs x nTimes input
+% V = V';
+% 
+% meanV = mean(V);
+% 
+% upV = resample(double(bsxfun(@minus,V, meanV)), q, 1) ;
+% 
+% deciV = upV(p+1:q:end,:);
+% 
+% %rV = bsxfun(@plus, resample(deciV, 1, q), meanV);
+% rV = bsxfun(@plus,deciV, meanV);
+% 
+% rV = rV';
 
 return


### PR DESCRIPTION
SubSampleShift previously used resample, which uses filtering and was seen to sometimes cause a huge error in the last sample, which turned into a large artifact in the total signal after further filtering. This version uses linear interpolation and the original last data point.